### PR TITLE
Create Nlp specific exceptions and raise

### DIFF
--- a/nlpsandboxclient/client.py
+++ b/nlpsandboxclient/client.py
@@ -3,6 +3,8 @@ import urllib.parse
 
 import requests
 
+from . import exceptions
+
 # Default data node endpoint is localhost
 DATA_NODE_ENDPOINT = "http://0.0.0.0:8080/api/v1"
 
@@ -50,6 +52,7 @@ class NlpClient:
         uri = self._build_uri(uri, endpoint=endpoint)
         requests_method_fn = getattr(self._requests_session, method)
         response = requests_method_fn(uri, data=data)
+        exceptions._raise_for_status(response)
         return response
 
     def _build_uri(self, uri, endpoint=None):

--- a/nlpsandboxclient/exceptions.py
+++ b/nlpsandboxclient/exceptions.py
@@ -6,8 +6,8 @@ class NlpError(Exception):
     """Generic exception thrown by the client."""
 
 
-class ClinicalNoteNotFound(NlpError, requests.exceptions.HTTPError):
-    """Clinical note not found"""
+class ResourceNotFound(NlpError, requests.exceptions.HTTPError):
+    """Resource not found"""
 
 
 class DataNodeServerError(NlpError, requests.exceptions.HTTPError):
@@ -20,6 +20,6 @@ def _raise_for_status(response):
     Catches and wraps NLP HTTP errors with appropriate text.
     """
     if response.status_code == 404:
-        raise ClinicalNoteNotFound(response.json()['title'], response)
+        raise ResourceNotFound(response.json()['title'], response)
     if response.status_code == 500:
         raise DataNodeServerError(response.json()['title'], response)

--- a/nlpsandboxclient/exceptions.py
+++ b/nlpsandboxclient/exceptions.py
@@ -1,0 +1,25 @@
+"""NLP client exceptions"""
+import requests
+
+
+class NlpError(Exception):
+    """Generic exception thrown by the client."""
+
+
+class ClinicalNoteNotFound(NlpError, requests.exceptions.HTTPError):
+    """Clinical note not found"""
+
+
+class DataNodeServerError(NlpError, requests.exceptions.HTTPError):
+    """Server error"""
+
+
+def _raise_for_status(response):
+    """
+    Replacement for requests.response.raise_for_status().
+    Catches and wraps NLP HTTP errors with appropriate text.
+    """
+    if response.status_code == 404:
+        raise ClinicalNoteNotFound(response.json()['title'], response)
+    if response.status_code == 500:
+        raise DataNodeServerError(response.json()['title'], response)


### PR DESCRIPTION
The exception looks like this:

```
In [2]: nlp = NlpClient()

In [3]: nlp.get_clinical_note("1")
---------------------------------------------------------------------------
ClinicalNoteNotFound                      Traceback (most recent call last)
<ipython-input-3-bca60308f748> in <module>
----> 1 nlp.get_clinical_note("1")

~/nlp-sandbox-client/nlpsandboxclient/client.py in get_clinical_note(self, noteid)
     33     def get_clinical_note(self, noteid=None):
     34         """Returns the clinical note for a given ID"""
---> 35         return self.rest_get(f"/notes/{noteid}")
     36 
     37     def get_health(self):

~/nlp-sandbox-client/nlpsandboxclient/client.py in rest_get(self, uri, endpoint)
     45     def rest_get(self, uri, endpoint=None):
     46         """Sends a HTTP GET request"""
---> 47         response = self._rest_call('get', uri, None, endpoint)
     48         return _return_rest_body(response)
     49 

~/nlp-sandbox-client/nlpsandboxclient/client.py in _rest_call(self, method, uri, data, endpoint)
     53         requests_method_fn = getattr(self._requests_session, method)
     54         response = requests_method_fn(uri, data=data)
---> 55         exceptions._raise_for_status(response)
     56         return response
     57 

~/nlp-sandbox-client/nlpsandboxclient/exceptions.py in _raise_for_status(response)
     21     """
     22     if response.status_code == 404:
---> 23         raise ClinicalNoteNotFound(response.json()['title'], response)
     24     if response.status_code == 500:
     25         raise DataNodeServerError(response.json()['title'], response)

ResourceNotFound: [Errno The specified resource was not found] <Response [404]>
```